### PR TITLE
chore: update docker-cd workflow to v0.0.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         if: github.event_name == 'push'
         needs: [lint, unit-test, browser-test, format, build]
         name: Deploy
-        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.26 # v0.0.25
         with:
             app-path: apps/bang
             service-name: bang
@@ -302,7 +302,7 @@ jobs:
         needs: temp-build
         permissions:
             deployments: write
-        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-deploy.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-deploy.yaml@v0.0.26 # v0.0.25
         with:
             app-path: apps/bang
             service-name: bang
@@ -317,7 +317,7 @@ jobs:
             (github.event.action == 'unlabeled' && github.event.label.name == 'temp-deploy')
         permissions:
             deployments: write
-        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-cleanup.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+        uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-cleanup.yaml@v0.0.26 # v0.0.25
         with:
             app-path: apps/bang
         secrets:


### PR DESCRIPTION
Updates pinned `wajeht/docker-cd-deploy-workflow` references to `v0.0.26`.

This picks up the temp deploy change that writes `x-docker-cd` config into the generated compose file instead of creating `docker-cd.yml`.