### PR TITLE
fix: correct url preview positioning

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -665,37 +665,61 @@ a:hover .sort-icon {
 
 .preview {
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    min-width: 0;
+    vertical-align: middle;
+    anchor-name: --preview;
+    anchor-scope: --preview;
+}
+
+.preview > a {
+    max-width: 100%;
+    min-width: 0;
 }
 
 .preview-img {
-    display: none;
-    position: fixed;
+    display: block;
+    position: absolute;
     z-index: 99999;
+    bottom: calc(100% + 6px);
+    left: 0;
     border: 1px solid var(--border-color);
     border-radius: 4px;
     width: 300px;
+    max-width: calc(100vw - 24px);
     height: 158px;
     object-fit: cover;
     background: var(--background-color);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-2px);
+    transition:
+        opacity 0.12s ease,
+        transform 0.12s ease,
+        visibility 0.12s ease;
 }
 
-.preview-loading {
-    display: none;
-    position: fixed;
-    z-index: 99999;
-    width: 300px;
-    height: 158px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--background-color);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    color: var(--text-color);
-    font-size: 0.9em;
+@supports (position-anchor: --preview) {
+    .preview-img {
+        position: fixed;
+        position-anchor: --preview;
+        top: auto;
+        right: auto;
+        bottom: anchor(top);
+        left: anchor(left);
+        margin-bottom: 6px;
+    }
+}
+
+.preview:hover .preview-img,
+.preview:focus-within .preview-img {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
 }
 
 [data-theme='dark'] .question-mark-btn {
@@ -936,8 +960,7 @@ a:hover .sort-icon {
     }
 
     dialog,
-    .preview-img,
-    .preview-loading {
+    .preview-img {
         display: none !important;
     }
 

--- a/src/routes/actions/actions-index.html
+++ b/src/routes/actions/actions-index.html
@@ -14,39 +14,8 @@ function handleRowHighlight() {
     }
 }
 
-function previewWebpageOnLinkHover() {
-    document.querySelectorAll('.preview').forEach(el => {
-        const img = el.querySelector('.preview-img');
-        const loader = document.createElement('div');
-        loader.className = 'preview-loading';
-        loader.textContent = 'Loading...';
-        el.appendChild(loader);
-
-        el.addEventListener('mouseenter', () => {
-            const rect = el.getBoundingClientRect();
-            const left = (rect.left + rect.width / 2) + 'px';
-            const top = (rect.top - 158 - 5) + 'px';
-            img.style.left = left;
-            img.style.top = top;
-            loader.style.left = left;
-            loader.style.top = top;
-            img.style.display = 'block';
-            if (!img.complete) loader.style.display = 'flex';
-        })
-
-        el.addEventListener('mouseleave', () => {
-            img.style.display = 'none';
-            loader.style.display = 'none';
-        })
-
-        img.onload = () => loader.style.display = 'none';
-    })
-}
-
 document.addEventListener('DOMContentLoaded', handleRowHighlight);
-document.addEventListener('DOMContentLoaded', previewWebpageOnLinkHover);
 window.addEventListener('load', handleRowHighlight);
-window.addEventListener('load', previewWebpageOnLinkHover);
 </script>
 
 <section style="display: flex; flex-direction: column; gap: 30px;">

--- a/src/routes/bookmarks/bookmarks-index.html
+++ b/src/routes/bookmarks/bookmarks-index.html
@@ -14,39 +14,8 @@ function handleRowHighlight() {
     }
 }
 
-function previewWebpageOnLinkHover() {
-    document.querySelectorAll('.preview').forEach(el => {
-        const img = el.querySelector('.preview-img');
-        const loader = document.createElement('div');
-        loader.className = 'preview-loading';
-        loader.textContent = 'Loading...';
-        el.appendChild(loader);
-
-        el.addEventListener('mouseenter', () => {
-            const rect = el.getBoundingClientRect();
-            const left = (rect.left + rect.width / 2) + 'px';
-            const top = (rect.top - 158 - 5) + 'px';
-            img.style.left = left;
-            img.style.top = top;
-            loader.style.left = left;
-            loader.style.top = top;
-            img.style.display = 'block';
-            if (!img.complete) loader.style.display = 'flex';
-        })
-
-        el.addEventListener('mouseleave', () => {
-            img.style.display = 'none';
-            loader.style.display = 'none';
-        })
-
-        img.onload = () => loader.style.display = 'none';
-    })
-}
-
 document.addEventListener('DOMContentLoaded', handleRowHighlight);
-document.addEventListener('DOMContentLoaded', previewWebpageOnLinkHover);
 window.addEventListener('load', handleRowHighlight);
-window.addEventListener('load', previewWebpageOnLinkHover);
 </script>
 
 <section style="display: flex; flex-direction: column; gap: 30px;">

--- a/src/routes/general/bangs-index.html
+++ b/src/routes/general/bangs-index.html
@@ -1,35 +1,3 @@
-<script>
-function previewWebpageOnLinkHover() {
-    document.querySelectorAll('.preview').forEach(el => {
-        const img = el.querySelector('.preview-img');
-        const loader = document.createElement('div');
-        loader.className = 'preview-loading';
-        loader.textContent = 'Loading...';
-        el.appendChild(loader);
-
-        el.addEventListener('mouseenter', () => {
-            const rect = el.getBoundingClientRect();
-            const left = (rect.left + rect.width / 2) + 'px';
-            const top = (rect.top - 158 - 5) + 'px';
-            img.style.left = left;
-            img.style.top = top;
-            loader.style.left = left;
-            loader.style.top = top;
-            img.style.display = 'block';
-            if (!img.complete) loader.style.display = 'flex';
-        })
-
-        el.addEventListener('mouseleave', () => {
-            img.style.display = 'none';
-            loader.style.display = 'none';
-        })
-
-        img.onload = () => loader.style.display = 'none';
-    })
-}
-
-document.addEventListener('DOMContentLoaded', previewWebpageOnLinkHover);
-</script>
 <section style="display: flex; flex-direction: column; gap: 30px;">
     <header style="display: flex; justify-content: space-between; align-items: center;">
         <div>

--- a/src/routes/reminders/reminders-index.html
+++ b/src/routes/reminders/reminders-index.html
@@ -14,37 +14,7 @@ function handleRowHighlight() {
     }
 }
 
-function previewWebpageOnLinkHover() {
-    document.querySelectorAll('.preview').forEach(el => {
-        const img = el.querySelector('.preview-img');
-        const loader = document.createElement('div');
-        loader.className = 'preview-loading';
-        loader.textContent = 'Loading...';
-        el.appendChild(loader);
-
-        el.addEventListener('mouseenter', () => {
-            const rect = el.getBoundingClientRect();
-            const left = (rect.left + rect.width / 2) + 'px';
-            const top = (rect.top - 158 - 5) + 'px';
-            img.style.left = left;
-            img.style.top = top;
-            loader.style.left = left;
-            loader.style.top = top;
-            img.style.display = 'block';
-            if (!img.complete) loader.style.display = 'flex';
-        })
-
-        el.addEventListener('mouseleave', () => {
-            img.style.display = 'none';
-            loader.style.display = 'none';
-        })
-
-        img.onload = () => loader.style.display = 'none';
-    })
-}
-
 document.addEventListener('DOMContentLoaded', handleRowHighlight);
-document.addEventListener('DOMContentLoaded', previewWebpageOnLinkHover);
 window.addEventListener('load', handleRowHighlight);
 </script>
 

--- a/src/routes/tabs/tabs-index.html
+++ b/src/routes/tabs/tabs-index.html
@@ -75,37 +75,7 @@
         }
     };
 
-    function previewWebpageOnLinkHover() {
-        document.querySelectorAll('.preview').forEach(el => {
-            const img = el.querySelector('.preview-img');
-            const loader = document.createElement('div');
-            loader.className = 'preview-loading';
-            loader.textContent = 'Loading...';
-            el.appendChild(loader);
-
-            el.addEventListener('mouseenter', () => {
-                const rect = el.getBoundingClientRect();
-                const left = (rect.left + rect.width / 2) + 'px';
-                const top = (rect.top - 158 - 5) + 'px';
-                img.style.left = left;
-                img.style.top = top;
-                loader.style.left = left;
-                loader.style.top = top;
-                img.style.display = 'block';
-                if (!img.complete) loader.style.display = 'flex';
-            })
-
-            el.addEventListener('mouseleave', () => {
-                img.style.display = 'none';
-                loader.style.display = 'none';
-            })
-
-            img.onload = () => loader.style.display = 'none';
-        })
-    }
-
     handleTabRowHighlight();
-    previewWebpageOnLinkHover();
     window.addEventListener('load', handleTabRowHighlight);
 
     document.getElementById('select-all-checkbox')?.addEventListener('change', function() {


### PR DESCRIPTION
## Summary
- remove duplicated JavaScript hover positioning for URL previews
- position previews with CSS anchor positioning and a CSS fallback
- apply the shared fix across actions, bookmarks, reminders, tabs, and bangs

## Tests
- npm test
- npm run build
- changed-file formatting check
- Chrome real-page preview geometry check