### PR TITLE
fix: prevent cached custom bang redirects

### DIFF
--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -987,6 +987,8 @@ describe('search', () => {
             expect(res.set).toHaveBeenCalledWith(
                 expect.objectContaining({
                     'Cache-Control': 'no-store', // Custom bangs should not be cached
+                    Pragma: 'no-cache',
+                    Expires: '0',
                 }),
             );
             expect(res.redirect).toHaveBeenCalledWith('https://example.com/search?q=test%20search');
@@ -1100,6 +1102,8 @@ describe('search', () => {
             expect(res.set).toHaveBeenCalledWith(
                 expect.objectContaining({
                     'Cache-Control': 'no-store', // Custom bangs should not be cached
+                    Pragma: 'no-cache',
+                    Expires: '0',
                 }),
             );
             expect(res.redirect).toHaveBeenCalledWith('https://mysite.com');

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -497,6 +497,8 @@ export function createSearch(context: AppContext) {
             if (cacheType === 'no-store') {
                 res.set({
                     'Cache-Control': 'no-store',
+                    Pragma: 'no-cache',
+                    Expires: '0',
                 });
             } else {
                 const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add legacy no-cache headers for no-store redirects
- assert custom bang redirects include the stronger no-cache headers

## Test plan
- npm run lint
- vp test --run src/utils/search.test.ts -t "should handle custom search bang"
- vp test --run src/utils/search.test.ts -t "should handle custom redirect bang"
- vp test --run src/utils/search.test.ts -t "should handle non-existent bang as search term"