### PR TITLE
fix: improve mobile responsiveness

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -922,12 +922,12 @@ a:hover .sort-icon {
 body > header > nav[aria-label='Main navigation'],
 body > header > nav[aria-label='Main navigation'] > div,
 body > header > nav[aria-label='Main navigation'] ul,
-nav[aria-label='Action management controls'],
-nav[aria-label='Action management controls'] form[action='/actions'],
-main > div:has(nav[aria-label='Settings navigation']),
-main > div:has(nav[aria-label='Settings navigation']) > aside,
-main > div:has(nav[aria-label='Settings navigation']) > section,
-main > div:has(nav[aria-label='Settings navigation']) > section > section {
+nav[aria-label$='management controls'],
+nav[aria-label$='management controls'] form[role='search'],
+main > div:has(> aside > nav),
+main > div:has(> aside > nav) > aside,
+main > div:has(> aside > nav) > section,
+main > div:has(> aside > nav) > section > section {
     min-width: 0;
 }
 
@@ -940,23 +940,23 @@ body > header > nav[aria-label='Main navigation'] ul a {
     white-space: nowrap;
 }
 
-nav[aria-label='Action management controls'] {
+nav[aria-label$='management controls'] {
     gap: 1rem;
     flex-wrap: wrap;
 }
 
-nav[aria-label='Action management controls'] form[action='/actions'] {
+nav[aria-label$='management controls'] form[role='search'] {
     flex: 1 1 18rem;
     min-width: min(100%, 18rem);
 }
 
-nav[aria-label='Action management controls'] form[action='/actions'] search,
-nav[aria-label='Action management controls'] form[action='/actions'] input[type='search'] {
+nav[aria-label$='management controls'] form[role='search'] search,
+nav[aria-label$='management controls'] form[role='search'] input[type='search'] {
     min-width: 0;
     width: 100%;
 }
 
-nav[aria-label='Action management controls'] button {
+nav[aria-label$='management controls'] button {
     min-width: 44px;
 }
 
@@ -993,24 +993,22 @@ table:has(td[data-label]) time {
     display: block;
 }
 
-main > div:has(nav[aria-label='Settings navigation']) > section > section > fieldset,
-main > div:has(nav[aria-label='Settings navigation']) > section > section > form > fieldset,
-main > div:has(nav[aria-label='Settings navigation']) > section > section > div > fieldset {
+main > div:has(> aside > nav) > section > section > fieldset,
+main > div:has(> aside > nav) > section > section > form > fieldset,
+main > div:has(> aside > nav) > section > section > div > fieldset {
     width: min(100%, 36rem) !important;
     max-width: 100% !important;
 }
 
-main
-    > div:has(nav[aria-label='Settings navigation'])
-    input:not([type='checkbox']):not([type='radio']),
-main > div:has(nav[aria-label='Settings navigation']) select,
-main > div:has(nav[aria-label='Settings navigation']) textarea {
+main > div:has(> aside > nav) input:not([type='checkbox']):not([type='radio']),
+main > div:has(> aside > nav) select,
+main > div:has(> aside > nav) textarea {
     width: 100%;
     min-width: 0;
 }
 
-main > div:has(nav[aria-label='Settings navigation']) input[type='checkbox'],
-main > div:has(nav[aria-label='Settings navigation']) input[type='radio'] {
+main > div:has(> aside > nav) input[type='checkbox'],
+main > div:has(> aside > nav) input[type='radio'] {
     flex: 0 0 auto;
 }
 
@@ -1067,48 +1065,53 @@ dialog {
         margin-left: auto;
     }
 
-    section:has(nav[aria-label='Action management controls']) > header {
+    header:has(nav[aria-label$='management controls']) {
         flex-direction: column;
         align-items: stretch !important;
     }
 
-    nav[aria-label='Action management controls'],
-    nav[aria-label='Action management controls'] form[action='/actions'] {
+    nav[aria-label$='management controls'],
+    nav[aria-label$='management controls'] form[role='search'] {
         width: 100%;
     }
 
-    nav[aria-label='Action management controls'] {
+    nav[aria-label$='management controls'] {
         gap: 0.5rem !important;
         justify-content: flex-start;
     }
 
-    nav[aria-label='Action management controls'] form[action='/actions'] {
+    nav[aria-label$='management controls'] form[role='search'] {
         flex-basis: 100%;
     }
 
-    nav[aria-label='Action management controls'] form[action='/actions'] button[type='submit'],
-    nav[aria-label='Action management controls'] > button,
-    nav[aria-label='Action management controls'] > form:not([action='/actions']) button {
+    nav[aria-label$='management controls'] form[role='search'] button[type='submit'],
+    nav[aria-label$='management controls'] > button,
+    nav[aria-label$='management controls'] > form:not([role='search']) button {
         min-height: 44px;
     }
 
     table:has(td[data-label]),
-    table:has(td[data-label]) tbody,
-    table:has(td[data-label]) tr,
-    table:has(td[data-label]) td {
+    table:has(td[data-label]) > tbody,
+    table:has(td[data-label]) > tbody > tr,
+    table:has(td[data-label]) > tbody > tr > td {
         display: block;
         width: 100%;
     }
 
-    table:has(td[data-label]) {
-        table-layout: auto;
+    table:has(td[data-label]) > tbody > tr > td:empty {
+        display: none;
     }
 
-    table:has(td[data-label]) thead {
+    table:has(td[data-label]) {
+        table-layout: auto;
+        min-width: 0 !important;
+    }
+
+    table:has(td[data-label]) > thead {
         display: none !important;
     }
 
-    table:has(td[data-label]) tr {
+    table:has(td[data-label]) > tbody > tr {
         padding: 0.75rem;
         margin-bottom: 0.75rem;
         border: 1px solid var(--tr-border-color);
@@ -1116,7 +1119,7 @@ dialog {
         background-color: var(--background-color);
     }
 
-    table:has(td[data-label]) td {
+    table:has(td[data-label]) > tbody > tr > td[data-label] {
         display: grid;
         grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr);
         gap: 0.75rem;
@@ -1126,27 +1129,27 @@ dialog {
         overflow: visible;
     }
 
-    table:has(td[data-label]) td::before {
+    table:has(td[data-label]) > tbody > tr > td[data-label]::before {
         content: attr(data-label);
         color: var(--text-muted-color);
         font-weight: 600;
     }
 
-    table:has(td[data-label]) td[data-label='Select'] {
+    table:has(td[data-label]) > tbody > tr > td[data-label='Select'] {
         display: flex;
         justify-content: flex-start;
     }
 
-    table:has(td[data-label]) td[data-label='Select']::before {
+    table:has(td[data-label]) > tbody > tr > td[data-label='Select']::before {
         content: '';
         display: none;
     }
 
-    table:has(td[data-label]) td[data-label='Actions'] {
+    table:has(td[data-label]) > tbody > tr > td[data-label='Actions'] {
         align-items: center;
     }
 
-    table:has(td[data-label]) td[data-label='Actions'] details {
+    table:has(td[data-label]) > tbody > tr > td[data-label='Actions'] details {
         justify-self: start;
     }
 
@@ -1164,41 +1167,41 @@ dialog {
         display: none;
     }
 
-    main > div:has(nav[aria-label='Settings navigation']) {
+    main > div:has(> aside > nav) {
         grid-template-columns: 1fr !important;
         gap: 1rem;
     }
 
-    main > div:has(nav[aria-label='Settings navigation']) > aside {
+    main > div:has(> aside > nav) > aside {
         height: auto !important;
         padding-right: 0 !important;
     }
 
-    nav[aria-label='Settings navigation'] ul {
+    main > div > aside > nav ul {
         flex-direction: row !important;
         gap: 0.75rem !important;
         overflow-x: auto;
         padding-bottom: 0.25rem !important;
     }
 
-    nav[aria-label='Settings navigation'] hr {
+    main > div > aside > nav hr {
         display: none;
     }
 
-    nav[aria-label='Settings navigation'] a {
+    main > div > aside > nav a {
         white-space: nowrap;
     }
 
-    main > div:has(nav[aria-label='Settings navigation']) > section {
+    main > div:has(> aside > nav) > section {
         border-top: 1px solid var(--aside-border-color);
         border-left: 0 !important;
         padding-top: 1rem;
         padding-left: 0 !important;
     }
 
-    main > div:has(nav[aria-label='Settings navigation']) > section > section > fieldset,
-    main > div:has(nav[aria-label='Settings navigation']) > section > section > form > fieldset,
-    main > div:has(nav[aria-label='Settings navigation']) > section > section > div > fieldset {
+    main > div:has(> aside > nav) > section > section > fieldset,
+    main > div:has(> aside > nav) > section > section > form > fieldset,
+    main > div:has(> aside > nav) > section > section > div > fieldset {
         width: 100% !important;
     }
 
@@ -1213,7 +1216,7 @@ dialog {
 }
 
 @media (max-width: 420px) {
-    table:has(td[data-label]) td {
+    table:has(td[data-label]) > tbody > tr > td[data-label] {
         grid-template-columns: 1fr;
         gap: 0.15rem;
     }

--- a/public/style.css
+++ b/public/style.css
@@ -932,8 +932,11 @@ main > div:has(> aside > nav) > section > section {
 }
 
 body > header > nav[aria-label='Main navigation'] ul {
-    overflow-x: auto;
-    scrollbar-width: thin;
+    flex-wrap: wrap;
+}
+
+body > header > nav[aria-label='Main navigation'] h1 {
+    white-space: nowrap;
 }
 
 body > header > nav[aria-label='Main navigation'] ul a {
@@ -1029,40 +1032,43 @@ dialog {
     }
 
     body > header > nav[aria-label='Main navigation'] {
-        align-items: flex-start !important;
-        flex-wrap: wrap;
-        gap: 0.75rem;
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 0.75rem 1rem;
     }
 
     body > header > nav[aria-label='Main navigation'] > div {
-        width: 100%;
-        align-items: flex-start !important;
-        flex-wrap: wrap;
-        gap: 0.75rem !important;
+        display: contents !important;
     }
 
     body > header > nav[aria-label='Main navigation'] h1 {
-        width: 100%;
+        grid-row: 1;
+        grid-column: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
         padding-right: 0 !important;
         line-height: 1.1;
     }
 
+    body > header > nav[aria-label='Main navigation'] > details {
+        grid-row: 1;
+        grid-column: 2;
+        justify-self: end;
+    }
+
     body > header > nav[aria-label='Main navigation'] ul {
-        width: 100%;
-        gap: 0.75rem !important;
-        padding-bottom: 0.25rem !important;
+        grid-row: 2;
+        grid-column: 1 / -1;
+        display: grid !important;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0 1rem !important;
     }
 
     body > header > nav[aria-label='Main navigation'] ul a {
-        display: inline-flex;
-        flex-direction: column;
-        align-items: center;
-        min-width: 4.75rem;
-        text-align: center;
-    }
-
-    body > header > nav[aria-label='Main navigation'] details {
-        margin-left: auto;
+        display: block;
+        padding: 0.4rem 0;
     }
 
     header:has(nav[aria-label$='management controls']) {
@@ -1178,10 +1184,9 @@ dialog {
     }
 
     main > div > aside > nav ul {
-        flex-direction: row !important;
-        gap: 0.75rem !important;
-        overflow-x: auto;
-        padding-bottom: 0.25rem !important;
+        display: grid !important;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.5rem 1rem !important;
     }
 
     main > div > aside > nav hr {
@@ -1207,6 +1212,15 @@ dialog {
 
     fieldset {
         padding: 0.75rem;
+    }
+
+    form[method='POST'][action='/search'] {
+        width: 100% !important;
+    }
+
+    nav[aria-label='Pagination navigation'] {
+        flex-wrap: wrap;
+        row-gap: 0.5rem;
     }
 
     dialog {

--- a/public/style.css
+++ b/public/style.css
@@ -919,6 +919,306 @@ a:hover .sort-icon {
     font-weight: bold;
 }
 
+body > header > nav[aria-label='Main navigation'],
+body > header > nav[aria-label='Main navigation'] > div,
+body > header > nav[aria-label='Main navigation'] ul,
+nav[aria-label='Action management controls'],
+nav[aria-label='Action management controls'] form[action='/actions'],
+main > div:has(nav[aria-label='Settings navigation']),
+main > div:has(nav[aria-label='Settings navigation']) > aside,
+main > div:has(nav[aria-label='Settings navigation']) > section,
+main > div:has(nav[aria-label='Settings navigation']) > section > section {
+    min-width: 0;
+}
+
+body > header > nav[aria-label='Main navigation'] ul {
+    overflow-x: auto;
+    scrollbar-width: thin;
+}
+
+body > header > nav[aria-label='Main navigation'] ul a {
+    white-space: nowrap;
+}
+
+nav[aria-label='Action management controls'] {
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+nav[aria-label='Action management controls'] form[action='/actions'] {
+    flex: 1 1 18rem;
+    min-width: min(100%, 18rem);
+}
+
+nav[aria-label='Action management controls'] form[action='/actions'] search,
+nav[aria-label='Action management controls'] form[action='/actions'] input[type='search'] {
+    min-width: 0;
+    width: 100%;
+}
+
+nav[aria-label='Action management controls'] button {
+    min-width: 44px;
+}
+
+table:has(td[data-label]) th,
+table:has(td[data-label]) td {
+    vertical-align: top;
+}
+
+table:has(td[data-label]) td {
+    overflow: hidden;
+}
+
+td[data-label='URL'] > div {
+    min-width: 0;
+}
+
+td[data-label='URL'] > div > img {
+    flex: 0 0 auto;
+}
+
+td[data-label='URL'] .preview {
+    min-width: 0;
+    width: 100%;
+}
+
+td[data-label='URL'] .preview > a {
+    display: block;
+    overflow: hidden !important;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+table:has(td[data-label]) time {
+    display: block;
+}
+
+main > div:has(nav[aria-label='Settings navigation']) > section > section > fieldset,
+main > div:has(nav[aria-label='Settings navigation']) > section > section > form > fieldset,
+main > div:has(nav[aria-label='Settings navigation']) > section > section > div > fieldset {
+    width: min(100%, 36rem) !important;
+    max-width: 100% !important;
+}
+
+main
+    > div:has(nav[aria-label='Settings navigation'])
+    input:not([type='checkbox']):not([type='radio']),
+main > div:has(nav[aria-label='Settings navigation']) select,
+main > div:has(nav[aria-label='Settings navigation']) textarea {
+    width: 100%;
+    min-width: 0;
+}
+
+main > div:has(nav[aria-label='Settings navigation']) input[type='checkbox'],
+main > div:has(nav[aria-label='Settings navigation']) input[type='radio'] {
+    flex: 0 0 auto;
+}
+
+dialog {
+    max-width: calc(100vw - 2rem);
+}
+
+@media (max-width: 700px) {
+    body {
+        padding: 0.75rem;
+    }
+
+    input,
+    button,
+    textarea,
+    select {
+        max-width: 100%;
+    }
+
+    body > header > nav[aria-label='Main navigation'] {
+        align-items: flex-start !important;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    body > header > nav[aria-label='Main navigation'] > div {
+        width: 100%;
+        align-items: flex-start !important;
+        flex-wrap: wrap;
+        gap: 0.75rem !important;
+    }
+
+    body > header > nav[aria-label='Main navigation'] h1 {
+        width: 100%;
+        padding-right: 0 !important;
+        line-height: 1.1;
+    }
+
+    body > header > nav[aria-label='Main navigation'] ul {
+        width: 100%;
+        gap: 0.75rem !important;
+        padding-bottom: 0.25rem !important;
+    }
+
+    body > header > nav[aria-label='Main navigation'] ul a {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        min-width: 4.75rem;
+        text-align: center;
+    }
+
+    body > header > nav[aria-label='Main navigation'] details {
+        margin-left: auto;
+    }
+
+    section:has(nav[aria-label='Action management controls']) > header {
+        flex-direction: column;
+        align-items: stretch !important;
+    }
+
+    nav[aria-label='Action management controls'],
+    nav[aria-label='Action management controls'] form[action='/actions'] {
+        width: 100%;
+    }
+
+    nav[aria-label='Action management controls'] {
+        gap: 0.5rem !important;
+        justify-content: flex-start;
+    }
+
+    nav[aria-label='Action management controls'] form[action='/actions'] {
+        flex-basis: 100%;
+    }
+
+    nav[aria-label='Action management controls'] form[action='/actions'] button[type='submit'],
+    nav[aria-label='Action management controls'] > button,
+    nav[aria-label='Action management controls'] > form:not([action='/actions']) button {
+        min-height: 44px;
+    }
+
+    table:has(td[data-label]),
+    table:has(td[data-label]) tbody,
+    table:has(td[data-label]) tr,
+    table:has(td[data-label]) td {
+        display: block;
+        width: 100%;
+    }
+
+    table:has(td[data-label]) {
+        table-layout: auto;
+    }
+
+    table:has(td[data-label]) thead {
+        display: none !important;
+    }
+
+    table:has(td[data-label]) tr {
+        padding: 0.75rem;
+        margin-bottom: 0.75rem;
+        border: 1px solid var(--tr-border-color);
+        border-radius: 4px;
+        background-color: var(--background-color);
+    }
+
+    table:has(td[data-label]) td {
+        display: grid;
+        grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr);
+        gap: 0.75rem;
+        align-items: start;
+        border: 0;
+        padding: 0.35rem 0 !important;
+        overflow: visible;
+    }
+
+    table:has(td[data-label]) td::before {
+        content: attr(data-label);
+        color: var(--text-muted-color);
+        font-weight: 600;
+    }
+
+    table:has(td[data-label]) td[data-label='Select'] {
+        display: flex;
+        justify-content: flex-start;
+    }
+
+    table:has(td[data-label]) td[data-label='Select']::before {
+        content: '';
+        display: none;
+    }
+
+    table:has(td[data-label]) td[data-label='Actions'] {
+        align-items: center;
+    }
+
+    table:has(td[data-label]) td[data-label='Actions'] details {
+        justify-self: start;
+    }
+
+    table:has(td[data-label]) details div[style*='position: absolute'] {
+        position: static !important;
+        width: 100%;
+        margin-top: 0.5rem;
+    }
+
+    td[data-label='URL'] > div {
+        max-width: 100%;
+    }
+
+    .preview-img {
+        display: none;
+    }
+
+    main > div:has(nav[aria-label='Settings navigation']) {
+        grid-template-columns: 1fr !important;
+        gap: 1rem;
+    }
+
+    main > div:has(nav[aria-label='Settings navigation']) > aside {
+        height: auto !important;
+        padding-right: 0 !important;
+    }
+
+    nav[aria-label='Settings navigation'] ul {
+        flex-direction: row !important;
+        gap: 0.75rem !important;
+        overflow-x: auto;
+        padding-bottom: 0.25rem !important;
+    }
+
+    nav[aria-label='Settings navigation'] hr {
+        display: none;
+    }
+
+    nav[aria-label='Settings navigation'] a {
+        white-space: nowrap;
+    }
+
+    main > div:has(nav[aria-label='Settings navigation']) > section {
+        border-top: 1px solid var(--aside-border-color);
+        border-left: 0 !important;
+        padding-top: 1rem;
+        padding-left: 0 !important;
+    }
+
+    main > div:has(nav[aria-label='Settings navigation']) > section > section > fieldset,
+    main > div:has(nav[aria-label='Settings navigation']) > section > section > form > fieldset,
+    main > div:has(nav[aria-label='Settings navigation']) > section > section > div > fieldset {
+        width: 100% !important;
+    }
+
+    fieldset {
+        padding: 0.75rem;
+    }
+
+    dialog {
+        width: calc(100vw - 2rem);
+        min-width: 0;
+    }
+}
+
+@media (max-width: 420px) {
+    table:has(td[data-label]) td {
+        grid-template-columns: 1fr;
+        gap: 0.15rem;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     html {
         scroll-behavior: auto;

--- a/src/routes/_layouts/admin.html
+++ b/src/routes/_layouts/admin.html
@@ -15,7 +15,7 @@
 
       <div style="display: grid; grid-template-columns: 15% 85%; flex: 1;">
         <aside style="display: inline-block; height: 100%; padding-right: 40px">
-          <nav>
+          <nav aria-label="Admin navigation">
             <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px;">
               <li>
                 <a style="font-weight: <%= path === '/admin/users' ? 'bold' : 'normal' %>; <%= path === '/admin/users' ? 'text-decoration: underline' : '' %>; display: block;" href="/admin/users">👥 Users</a>
@@ -36,9 +36,9 @@
           </nav>
         </aside>
 
-        <div style="display: inline-block; border-left: solid 1px var(--aside-border-color); padding-left: 30px">
+        <section style="display: inline-block; border-left: solid 1px var(--aside-border-color); padding-left: 30px">
           <%~ body %>
-        </div>
+        </section>
       </div>
     </main>
 

--- a/src/routes/actions/actions-index.html
+++ b/src/routes/actions/actions-index.html
@@ -203,19 +203,19 @@ window.addEventListener('load', handleRowHighlight);
                 <tbody>
                     <% for (let i = 0; i < data.length; i++) { %>
                         <tr data-id="<%~ data[i].id %>">
-                            <td style="padding: 10px;">
+                            <td data-label="Select" style="padding: 10px;">
                                 <input type="checkbox" name="id[]" value="<%~ data[i].id %>" class="action-checkbox" data-title="<%~ data[i].name %>" aria-label="Select <%= utils.stripHtmlTags(data[i].name) %>" />
                             </td>
                             <% if (state.user.column_preferences?.actions?.name !== false) { %>
-                                <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"><%~ data[i].name %></td>
+                                <td data-label="Name" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"><%~ data[i].name %></td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.trigger !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Trigger" style="padding: 10px;">
                                     <code><%~ data[i].trigger %></code>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.url !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="URL" style="padding: 10px;">
                                     <% if (data[i].url) { %>
                                     <div style="display: flex; gap: 5px; align-items: center;">
                                         <img loading="lazy" src= "<%~ utils.getFaviconUrl(data[i].url) %>" style="width: 16px; height: 16px; border-radius: 50%;">
@@ -232,19 +232,19 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.action_type !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Type" style="padding: 10px;">
                                     <code><%~ data[i].action_type %></code>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.created_at !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Created" style="padding: 10px;">
                                     <time datetime="<%= data[i].created_at %>">
                                         <%= utils.formatDateInTimezone(data[i].created_at, state.user.timezone).fullString %>
                                     </time>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.last_read_at !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Last Read" style="padding: 10px;">
                                     <% if (data[i].last_read_at) { %>
                                         <time datetime="<%= data[i].last_read_at %>">
                                             <%= utils.formatDateInTimezone(data[i].last_read_at, state.user.timezone).fullString %>
@@ -255,7 +255,7 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.usage_count !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Usage" style="padding: 10px;">
                                     <% const usageCount = data[i].usage_count || 0; %>
                                     <span style="display: flex; align-items: center; gap: 4px;">
                                         <%= usageCount %>
@@ -266,7 +266,7 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.actions?.hidden !== false && state.user.hidden_items_password) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Hidden" style="padding: 10px;">
                                     <% if (data[i].hidden == 1) { %>
                                         ✅
                                     <% } else { %>
@@ -274,7 +274,7 @@ window.addEventListener('load', handleRowHighlight);
                                     <% } %>
                                 </td>
                             <% } %>
-                            <td style="padding: 10px;">
+                            <td data-label="Actions" style="padding: 10px;">
                                 <details style="position: relative;">
                                     <summary aria-label="Actions for <%= utils.stripHtmlTags(data[i].name) %>">Actions</summary>
                                     <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">

--- a/src/routes/actions/actions.browser-test.ts
+++ b/src/routes/actions/actions.browser-test.ts
@@ -45,4 +45,28 @@ test.describe('Actions', () => {
         await page.getByRole('searchbox').press('Enter');
         await expect(page).toHaveURL(`${baseURL}/search/results?q=hello%20world`);
     });
+
+    test('keeps action list readable on mobile', async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto('/actions/create');
+
+        await page.getByLabel('⚡ Trigger').fill('mobileaction');
+        await page.getByLabel('📝 Name').fill('Mobile Action');
+        await page
+            .getByLabel('🌐 URL')
+            .fill('https://example.com/search?q={{{s}}}&with=a-very-long-query-string');
+        await page.getByLabel('🏷️ Action Type').selectOption('search');
+        await page.getByRole('button', { name: '💾 Save' }).click();
+
+        await expect(page).toHaveURL('/actions');
+        await expect(page.locator('table:has(td[data-label="Trigger"]) thead')).toBeHidden();
+        await expect(page.locator('td[data-label="Trigger"]').first()).toContainText(
+            '!mobileaction',
+        );
+
+        const horizontalOverflow = await page.evaluate(
+            () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        );
+        expect(horizontalOverflow).toBeLessThanOrEqual(1);
+    });
 });

--- a/src/routes/admin/admin-users-index.html
+++ b/src/routes/admin/admin-users-index.html
@@ -107,7 +107,7 @@
         <tbody>
           <% data.forEach(function(user) { %>
             <tr>
-              <td style="padding: 10px;">
+              <td data-label="Select" style="padding: 10px;">
                 <input
                   type="checkbox"
                   name="id[]"
@@ -118,25 +118,25 @@
                 />
               </td>
               <% if (state.user.column_preferences?.users?.username !== false) { %>
-                <td style="padding: 10px;"><%~ utils.highlightSearchTerm(user.username, search) %></td>
+                <td data-label="Username" style="padding: 10px;"><%~ utils.highlightSearchTerm(user.username, search) %></td>
               <% } %>
               <% if (state.user.column_preferences?.users?.email !== false) { %>
-                <td style="padding: 10px;"><%~ utils.highlightSearchTerm(user.email, search) %></td>
+                <td data-label="Email" style="padding: 10px;"><%~ utils.highlightSearchTerm(user.email, search) %></td>
               <% } %>
               <% if (state.user.column_preferences?.users?.is_admin !== false) { %>
-                <td style="padding: 10px;"><%= user.is_admin ? '✅' : '❌' %></td>
+                <td data-label="Admin" style="padding: 10px;"><%= user.is_admin ? '✅' : '❌' %></td>
               <% } %>
               <% if (state.user.column_preferences?.users?.email_verified_at !== false) { %>
-                <td style="padding: 10px;"><%= user.email_verified_at ? '✅' : '❌' %></td>
+                <td data-label="Verified" style="padding: 10px;"><%= user.email_verified_at ? '✅' : '❌' %></td>
               <% } %>
               <% if (state.user.column_preferences?.users?.created_at !== false) { %>
-                <td style="padding: 10px;">
+                <td data-label="Created" style="padding: 10px;">
                   <time datetime="<%= user.created_at %>">
                     <%= utils.formatDateInTimezone(user.created_at, state.user.timezone).fullString %>
                   </time>
                 </td>
               <% } %>
-              <td style="padding: 10px;">
+              <td data-label="Actions" style="padding: 10px;">
                 <div style="display: flex; gap: 10px;">
                   <button
                       type="button"

--- a/src/routes/bookmarks/bookmarks-index.html
+++ b/src/routes/bookmarks/bookmarks-index.html
@@ -158,17 +158,17 @@ window.addEventListener('load', handleRowHighlight);
                 <tbody>
                     <% for (let i = 0; i < data.length; i++) { %>
                         <tr data-id="<%~ data[i].id %>">
-                            <td style="padding: 10px;">
+                            <td data-label="Select" style="padding: 10px;">
                                 <input type="checkbox" name="id[]" value="<%~ data[i].id %>" class="bookmark-checkbox" data-title="<%~ data[i].title || 'Untitled' %>" aria-label="Select <%= utils.stripHtmlTags(data[i].title || 'Untitled') %>" />
                             </td>
                             <% if (state.user.column_preferences?.bookmarks?.title !== false) { %>
-                                <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                     <% if (data[i].pinned) { %>📌<% } %>
                                     <%~ data[i].title || 'Untitled' %>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.bookmarks?.url !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="URL" style="padding: 10px;">
                                     <div style="display: flex; gap: 5px; align-items: center;">
                                         <img loading="lazy" src= "<%~ utils.getFaviconUrl(data[i].url) %>" style="width: 16px; height: 16px; border-radius: 50%;">
                                         <span class="preview">
@@ -181,19 +181,19 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.bookmarks?.pinned !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Pinned" style="padding: 10px;">
                                     <%= data[i].pinned ? '📌 Yes' : '📍 No' %>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.bookmarks?.created_at !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Created" style="padding: 10px;">
                                     <time datetime="<%= data[i].created_at %>">
                                         <%= utils.formatDateInTimezone(data[i].created_at, state.user.timezone).fullString %>
                                     </time>
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.bookmarks?.hidden !== false && state.user.hidden_items_password) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Hidden" style="padding: 10px;">
                                     <% if (data[i].hidden == 1) { %>
                                         ✅
                                     <% } else { %>
@@ -201,7 +201,7 @@ window.addEventListener('load', handleRowHighlight);
                                     <% } %>
                                 </td>
                             <% } %>
-                            <td style="padding: 10px;">
+                            <td data-label="Actions" style="padding: 10px;">
                                 <details style="position: relative;">
                                     <summary aria-label="Actions for <%= utils.stripHtmlTags(data[i].title || 'Untitled') %>">Actions</summary>
                                     <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">

--- a/src/routes/bookmarks/bookmarks.browser-test.ts
+++ b/src/routes/bookmarks/bookmarks.browser-test.ts
@@ -112,4 +112,26 @@ test.describe('Bookmarks', () => {
         await page.goto('/reminders');
         await expect(page.locator('body')).not.toContainText('Read Documentation');
     });
+
+    test('keeps bookmark list readable on mobile', async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto('/bookmarks/create');
+
+        await page.getByLabel('📝 Name').fill('Mobile Bookmark');
+        await page
+            .getByLabel('🌐 URL')
+            .fill('https://example.com/some/deep/path?with=a-very-long-query-string');
+        await page.getByRole('button', { name: '💾 Save' }).click();
+
+        await expect(page).toHaveURL('/bookmarks');
+        await expect(page.locator('table:has(td[data-label="Title"]) thead')).toBeHidden();
+        await expect(page.locator('td[data-label="Title"]').first()).toContainText(
+            'Mobile Bookmark',
+        );
+
+        const horizontalOverflow = await page.evaluate(
+            () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        );
+        expect(horizontalOverflow).toBeLessThanOrEqual(1);
+    });
 });

--- a/src/routes/general/bangs-index.html
+++ b/src/routes/general/bangs-index.html
@@ -137,19 +137,19 @@
                     <% for (let i = 0; i < data.length; i++) { %>
                         <tr>
                             <!-- Suggestion/Name (s) -->
-                             <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"><%~ data[i].s %></td>
+                             <td data-label="Name" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"><%~ data[i].s %></td>
                             <!-- Trigger (t) -->
-                            <td style="padding: 10px;">
+                            <td data-label="Trigger" style="padding: 10px;">
                                 <code>!<%~ data[i].t %></code>
                             </td>
                             <!-- Domain (d) -->
-                            <td style="padding: 10px;">
+                            <td data-label="Domain" style="padding: 10px;">
                                 <a href="https://<%~ data[i].d %>" title="<%~ data[i].d %>" target="_blank" rel="noopener noreferrer">
                                     <%~ data[i].d %>
                                 </a>
                             </td>
                              <!-- URL (u) -->
-                             <td style="padding: 10px; white-space: nowrap; overflow: auto;">
+                             <td data-label="URL" style="padding: 10px; white-space: nowrap; overflow: auto;">
                                 <div style="display: flex; gap: 5px; align-items: center;">
                                     <img loading="lazy" src= "<%~ utils.getFaviconUrl(data[i].u) %>" style="width: 16px; height: 16px; border-radius: 50%;">
                                     <span class="preview">
@@ -161,11 +161,11 @@
                                 </div>
                             </td>
                              <!-- Category (c) -->
-                             <td style="padding: 10px;"><%~ data[i].c %></td>
+                             <td data-label="Category" style="padding: 10px;"><%~ data[i].c %></td>
                              <!-- Subcategory (sc) -->
-                             <td style="padding: 10px;"><%~ data[i].sc %></td>
+                             <td data-label="Subcategory" style="padding: 10px;"><%~ data[i].sc %></td>
                              <!-- Rank (r) -->
-                             <td style="padding: 10px;"><%~ data[i].r %></td>
+                             <td data-label="Rank" style="padding: 10px;"><%~ data[i].r %></td>
                         </tr>
                     <% } %>
                 </tbody>

--- a/src/routes/notes/notes-index.html
+++ b/src/routes/notes/notes-index.html
@@ -239,11 +239,11 @@ window.addEventListener('load', handleRowHighlight);
                     <tbody>
                         <% for (let i = 0; i < data.length; i++) { %>
                             <tr data-id="<%~ data[i].id %>">
-                                <td style="padding: 10px;">
+                                <td data-label="Select" style="padding: 10px;">
                                     <input type="checkbox" name="id[]" value="<%~ data[i].id %>" class="note-checkbox" data-title="<%~ data[i].title || 'Untitled' %>" />
                                 </td>
                                 <% if (state.user.column_preferences?.notes?.title !== false) { %>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <% if (data[i].pinned) { %>📌<% } %>
                                         <a href="/notes/<%= data[i].id %>" title="<%= utils.stripHtmlTags(data[i].title) %>">
                                             <% if (search && data[i].title) { %>
@@ -255,7 +255,7 @@ window.addEventListener('load', handleRowHighlight);
                                     </td>
                                 <% } %>
                                 <% if (state.user.column_preferences?.notes?.content !== false) { %>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Content" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <% if (search && data[i].content) { %>
                                             <%~ data[i].content %>
                                         <% } else { %>
@@ -264,19 +264,19 @@ window.addEventListener('load', handleRowHighlight);
                                     </td>
                                 <% } %>
                                 <% if (state.user.column_preferences?.notes?.pinned !== false) { %>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Pinned" style="padding: 10px;">
                                         <%= data[i].pinned ? '📌 Yes' : '📍 No' %>
                                     </td>
                                 <% } %>
                                 <% if (state.user.column_preferences?.notes?.created_at !== false) { %>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= data[i].created_at %>">
                                             <%= utils.formatDateInTimezone(data[i].created_at, state.user.timezone).fullString %>
                                         </time>
                                     </td>
                                 <% } %>
                                 <% if (state.user.column_preferences?.notes?.hidden !== false && state.user.hidden_items_password) { %>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Hidden" style="padding: 10px;">
                                         <% if (data[i].hidden == 1) { %>
                                             ✅
                                         <% } else { %>
@@ -284,7 +284,7 @@ window.addEventListener('load', handleRowHighlight);
                                         <% } %>
                                     </td>
                                 <% } %>
-                                <td style="padding: 10px;">
+                                <td data-label="Actions" style="padding: 10px;">
                                     <details style="position: relative;">
                                         <summary aria-label="Actions for note <%= utils.stripHtmlTags(data[i].title) %>">Actions</summary>
                                         <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">

--- a/src/routes/notes/notes-show.html
+++ b/src/routes/notes/notes-show.html
@@ -12,7 +12,7 @@
             </div>
         </div>
 
-        <div style="display: flex; gap: 10px;">
+        <nav style="display: flex; gap: 10px;" aria-label="Note management controls">
             <button type="button" onclick="location.href='/notes'" aria-label="Go back to notes list">← Back to Notes</button>
             <form method="POST" action="/notes/<%= note.id %>/pin" style="display: inline;">
                 <input type="hidden" name="csrfToken" value="<%= csrfToken %>" />
@@ -24,7 +24,7 @@
             <button type="button" onclick="location.href='/notes/<%= note.id %>/download'" aria-label="Download this note as markdown">⬇️ Download</button>
             <button type="button" onclick="location.href='/notes/<%= note.id %>/edit'" aria-label="Edit this note">✏️ Edit</button>
             <button type="button" onclick="document.getElementById('delete-note-modal').showModal()" aria-label="Delete this note">🗑️ Delete</button>
-        </div>
+        </nav>
     </header>
 
     <article style="background-color: var(--background-color); border-style: solid; border-width: 1px; border-radius: 4px; border-color: var(--card-border-color); padding: 20px; display: flex; flex-direction: column; gap: 10px;">

--- a/src/routes/reminders/reminders-index.html
+++ b/src/routes/reminders/reminders-index.html
@@ -142,11 +142,11 @@ window.addEventListener('load', handleRowHighlight);
                 <tbody>
                     <% for (let i = 0; i < reminders.length; i++) { %>
                         <tr data-id="<%~ reminders[i].id %>">
-                            <td style="padding: 10px;">
+                            <td data-label="Select" style="padding: 10px;">
                                 <input type="checkbox" name="id[]" value="<%~ reminders[i].id %>" class="reminder-checkbox" data-title="<%~ reminders[i].title %>" aria-label="Select <%= utils.stripHtmlTags(reminders[i].title) %>" />
                             </td>
                             <% if (state.user.column_preferences?.reminders?.title !== false) { %>
-                                <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                     <% if (reminders[i].title && utils.isUrlLike(reminders[i].title)) { %>
                                         <div style="display: flex; gap: 5px; align-items: center;">
                                             <img loading="lazy" src="<%~ utils.getFaviconUrl(reminders[i].title.startsWith('http') ? reminders[i].title : 'https://' + reminders[i].title) %>" style="width: 16px; height: 16px; border-radius: 50%;">
@@ -163,7 +163,7 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.reminders?.content !== false) { %>
-                                <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                <td data-label="Content" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                     <% if (reminders[i].content) { %>
                                         <% if (utils.isUrlLike(reminders[i].content)) { %>
                                             <div style="display: flex; gap: 5px; align-items: center;">
@@ -184,7 +184,7 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.reminders?.due_date !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Schedule" style="padding: 10px;">
                                     <% if (reminders[i].reminder_type === 'once') { %>
                                         <!-- One-time reminder: MUST show specific date and time -->
                                         <% if (reminders[i].due_date) { %>
@@ -210,7 +210,7 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.reminders?.next_due !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Next Due" style="padding: 10px;">
                                     <% if (reminders[i].due_date) { %>
                                         <time datetime="<%= reminders[i].due_date %>">
                                             <%
@@ -224,13 +224,13 @@ window.addEventListener('load', handleRowHighlight);
                                 </td>
                             <% } %>
                             <% if (state.user.column_preferences?.reminders?.created_at !== false) { %>
-                                <td style="padding: 10px;">
+                                <td data-label="Created" style="padding: 10px;">
                                     <time datetime="<%= reminders[i].created_at %>">
                                         <%= utils.formatDateInTimezone(reminders[i].created_at, state.user.timezone).fullString %>
                                     </time>
                                 </td>
                             <% } %>
-                            <td style="padding: 10px;">
+                            <td data-label="Actions" style="padding: 10px;">
                                 <details style="position: relative;">
                                     <summary aria-label="Actions for reminder <%= utils.stripHtmlTags(reminders[i].title) %>">Actions</summary>
                                     <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">

--- a/src/routes/search/search-results.html
+++ b/src/routes/search/search-results.html
@@ -57,27 +57,27 @@
                         <% if (results.bookmarks.data && results.bookmarks.data.length > 0) { %>
                             <% results.bookmarks.data.forEach(function(bookmark) { %>
                                 <tr>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Type" style="padding: 10px;">
                                         <a href="/bookmarks?id=<%~ bookmark.id %>">⭐️ Bookmark</a>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <%~ bookmark.title || 'Untitled' %>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Trigger" style="padding: 10px;">-</td>
+                                    <td data-label="URL" style="padding: 10px;">
                                         <a href="<%= utils.stripHtmlTags(bookmark.url) %>" style="overflow: auto; white-space: nowrap; display: flex; align-items: center; gap: 5px;" title="<%= utils.stripHtmlTags(bookmark.title) %>" target="_blank" rel="noopener noreferrer">
                                             <img loading="lazy" src="<%~ utils.getFaviconUrl(utils.stripHtmlTags(bookmark.url)) %>" style="width: 16px; height: 16px; border-radius: 50%;">
                                             <%~ bookmark.url %>
                                         </a>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Details" style="padding: 10px;">-</td>
+                                    <td data-label="Status" style="padding: 10px;">
                                         <%= bookmark.pinned ? '📌 Pinned' : '📍 Unpinned' %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= bookmark.created_at %>"><%= utils.formatDateInTimezone(bookmark.created_at, state.user.timezone).fullString %></time>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                         <details style="position: relative;">
                                             <summary aria-label="Actions for <%= utils.stripHtmlTags(bookmark.title) || 'Untitled' %>">Actions</summary>
                                             <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">
@@ -94,35 +94,35 @@
                         <% if (results.actions.data && results.actions.data.length > 0) { %>
                             <% results.actions.data.forEach(function(action) { %>
                                 <tr>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Type" style="padding: 10px;">
                                         <a href="/actions?id=<%~ action.id %>">🚀 Action</a>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <%~ action.name %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Trigger" style="padding: 10px;">
                                         <code style="background: var(--code-background); padding: 2px 6px; border-radius: 4px; font-size: 0.8em;"><%~ action.trigger %></code>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="URL" style="padding: 10px;">
                                         <a href="<%= utils.stripHtmlTags(action.url) %>" style="overflow: auto; white-space: nowrap; display: flex; align-items: center; gap: 5px;" title="<%= utils.stripHtmlTags(action.url) %>" target="_blank" rel="noopener noreferrer">
                                             <img loading="lazy" src="<%~ utils.getFaviconUrl(utils.stripHtmlTags(action.url)) %>" style="width: 16px; height: 16px; border-radius: 50%;">
                                             <%~ action.url %>
                                         </a>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Details" style="padding: 10px;">
                                         <code style="background: var(--code-background); padding: 2px 6px; border-radius: 4px; font-size: 0.8em;"><%~ action.action_type %></code>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Status" style="padding: 10px;">
                                         <% if (action.usage_count) { %>
                                             📊 <%= action.usage_count %> uses
                                         <% } else { %>
                                             📊 0 uses
                                         <% } %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= action.created_at %>"><%= utils.formatDateInTimezone(action.created_at, state.user.timezone).fullString %></time>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                         <details style="position: relative;">
                                             <summary aria-label="Actions for <%= utils.stripHtmlTags(action.name) %>">Actions</summary>
                                             <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">
@@ -139,26 +139,26 @@
                         <% if (results.notes.data && results.notes.data.length > 0) { %>
                             <% results.notes.data.forEach(function(note) { %>
                                 <tr>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Type" style="padding: 10px;">
                                         <a href="/notes?id=<%~ note.id %>">📝 Note</a>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <a href="/notes/<%= note.id %>" title="<%= utils.stripHtmlTags(note.title) %>">
                                             <%~ note.title %>
                                         </a>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Trigger" style="padding: 10px;">-</td>
+                                    <td data-label="URL" style="padding: 10px;">-</td>
+                                    <td data-label="Details" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <%~ note.content ? note.content.substring(0, 100) + (note.content.length > 100 ? '...' : '') : 'No content' %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Status" style="padding: 10px;">
                                         <%= note.pinned ? '📌 Pinned' : '📍 Unpinned' %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= note.created_at %>"><%= utils.formatDateInTimezone(note.created_at, state.user.timezone).fullString %></time>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                         <details style="position: relative;">
                                             <summary aria-label="Actions for note <%= utils.stripHtmlTags(note.title) %>">Actions</summary>
                                             <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">
@@ -175,24 +175,24 @@
                         <% if (results.tabs && results.tabs.length > 0) { %>
                             <% results.tabs.forEach(function(tab) { %>
                                 <tr>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Type" style="padding: 10px;">
                                         <a href="/tabs?id=<%~ tab.id %>">🔗 Tab</a>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <%~ tab.title %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Trigger" style="padding: 10px;">
                                         <code style="background: var(--code-background); padding: 2px 6px; border-radius: 4px; font-size: 0.8em;"><%~ tab.trigger %></code>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="URL" style="padding: 10px;">-</td>
+                                    <td data-label="Details" style="padding: 10px;">
                                         <span style="background: var(--tag-background); color: var(--tag-color); padding: 2px 8px; border-radius: 12px; font-size: 0.8em;"><%= tab.items_count %> items</span>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Status" style="padding: 10px;">-</td>
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= tab.created_at %>"><%= utils.formatDateInTimezone(tab.created_at, state.user.timezone).fullString %></time>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                         <details style="position: relative;">
                                             <summary aria-label="Actions for tab <%= utils.stripHtmlTags(tab.title) %>">Actions</summary>
                                             <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">
@@ -209,16 +209,16 @@
                         <% if (results.reminders.data && results.reminders.data.length > 0) { %>
                             <% results.reminders.data.forEach(function(reminder) { %>
                                 <tr>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Type" style="padding: 10px;">
                                         <a href="/reminders?id=<%~ reminder.id %>">⏰ Reminder</a>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Title" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <a href="/reminders?id=<%= reminder.id %>" title="<%= utils.stripHtmlTags(reminder.title) %>">
                                             <%~ reminder.title %>
                                         </a>
                                     </td>
-                                    <td style="padding: 10px;">-</td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Trigger" style="padding: 10px;">-</td>
+                                    <td data-label="URL" style="padding: 10px;">
                                         <% if (reminder.content && reminder.content.startsWith('http')) { %>
                                             <a href="<%= utils.stripHtmlTags(reminder.content) %>" target="_blank" rel="noopener noreferrer" style="overflow: auto; white-space: nowrap; display: flex; align-items: center; gap: 5px;" title="<%= utils.stripHtmlTags(reminder.content) %>">
                                                 <img loading="lazy" src="<%~ utils.getFaviconUrl(utils.stripHtmlTags(reminder.content)) %>" style="width: 16px; height: 16px; border-radius: 50%;">
@@ -228,24 +228,24 @@
                                             -
                                         <% } %>
                                     </td>
-                                    <td style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <td data-label="Details" style="padding: 10px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
                                         <% if (reminder.content && !reminder.content.startsWith('http')) { %>
                                             <%~ reminder.content.substring(0, 100) + (reminder.content.length > 100 ? '...' : '') %>
                                         <% } else { %>
                                             <code style="background: var(--code-background); padding: 2px 6px; border-radius: 4px; font-size: 0.8em;"><%= reminder.frequency || 'once' %></code>
                                         <% } %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Status" style="padding: 10px;">
                                         <% if (reminder.due_date) { %>
                                             ⏰ <%= utils.formatDateInTimezone(reminder.due_date, state.user.timezone).fullString %>
                                         <% } else { %>
                                             -
                                         <% } %>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Created" style="padding: 10px;">
                                         <time datetime="<%= reminder.created_at %>"><%= utils.formatDateInTimezone(reminder.created_at, state.user.timezone).fullString %></time>
                                     </td>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                         <details style="position: relative;">
                                             <summary aria-label="Actions for reminder <%= utils.stripHtmlTags(reminder.title) %>">Actions</summary>
                                             <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 150px; gap: 10px;" role="menu">

--- a/src/routes/settings/settings.browser-test.ts
+++ b/src/routes/settings/settings.browser-test.ts
@@ -25,4 +25,36 @@ test.describe('Settings', () => {
 
         await expect(page.locator('summary')).toContainText('testuser_updated');
     });
+
+    test('keeps account settings readable on mobile', async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto('/settings/account');
+
+        await expect(page.getByRole('heading', { name: '👤 Account' })).toBeVisible();
+        await expect(
+            page.locator('main > div:has(nav[aria-label="Settings navigation"]) fieldset').first(),
+        ).toBeVisible();
+
+        const settingsLayout = page.locator(
+            'main > div:has(nav[aria-label="Settings navigation"])',
+        );
+        const columnCount = await settingsLayout.evaluate((element) => {
+            return getComputedStyle(element).gridTemplateColumns.split(' ').length;
+        });
+        expect(columnCount).toBe(1);
+
+        const cardWidth = await page
+            .locator('main > div:has(nav[aria-label="Settings navigation"]) fieldset')
+            .first()
+            .evaluate((element) => {
+                return Math.ceil(element.getBoundingClientRect().width);
+            });
+        const viewportWidth = await page.evaluate(() => document.documentElement.clientWidth);
+        expect(cardWidth).toBeLessThanOrEqual(viewportWidth);
+
+        const horizontalOverflow = await page.evaluate(
+            () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        );
+        expect(horizontalOverflow).toBeLessThanOrEqual(1);
+    });
 });

--- a/src/routes/tabs/tabs-index.html
+++ b/src/routes/tabs/tabs-index.html
@@ -5,7 +5,7 @@
     if (searchParam && searchParam.trim() !== '') {
         const allDetailsRows = document.querySelectorAll('[id^="details-"]');
         allDetailsRows.forEach(row => {
-            row.style.display = 'table-row';
+            row.style.display = '';
         });
     }
 
@@ -16,7 +16,7 @@
             const tabId = this.dataset.tabId;
             const detailsRow = document.getElementById('details-' + tabId);
             if (detailsRow.style.display === 'none') {
-                detailsRow.style.display = 'table-row';
+                detailsRow.style.display = '';
             } else {
                 detailsRow.style.display = 'none';
             }
@@ -51,7 +51,7 @@
             }
 
             if (detailsRow.style.display === 'none') {
-                detailsRow.style.display = 'table-row'; // expand
+                detailsRow.style.display = ''; // expand
                 event.target.style.cursor = 'n-resize'; // immediately show up arrow
             } else {
                 detailsRow.style.display = 'none'; // collapse
@@ -195,7 +195,7 @@ section:has(.tab-checkbox:checked) #delete-selected-btn {
           </div>
           <p>Manage your saved tab groups <span style="color: red">(using Tabs requires you to have popup allowed/redirect on <code><%= state.branding.appUrl %></code> )</span></p>
       </div>
-      <div style="display: flex; gap: 10px;">
+      <nav style="display: flex; gap: 10px;" aria-label="Tab group management controls">
         <form method="GET" action="/tabs" style="display: flex; gap: 10px;" role="search">
             <%~ include('../_components/inputs/search.html', {
                 id: 'search',
@@ -218,7 +218,7 @@ section:has(.tab-checkbox:checked) #delete-selected-btn {
         </form>
         <!-- <button type="button" aria-label="Delete all tab groups" onclick="document.getElementById('delete-all-tabs-modal').showModal()">🗑️</button> -->
         <%~ include('../_components/column-settings.html') %>
-      </div>
+      </nav>
   </header>
 
   <section style="display: flex; flex-direction: column; gap: 10px;">
@@ -291,26 +291,26 @@ section:has(.tab-checkbox:checked) #delete-selected-btn {
               <tbody>
                   <% for (let i = 0; i < tabs.length; i++) { %>
                       <tr class="tab-group-row" data-tab-id="<%= tabs[i].id %>" data-id="<%= tabs[i].id %>" style="cursor: pointer;">
-                          <td style="padding: 10px;">
+                          <td data-label="Select" style="padding: 10px;">
                               <input type="checkbox" name="id[]" value="<%~ tabs[i].id %>" class="tab-checkbox" data-title="<%~ tabs[i].title || 'Untitled' %>" data-items="<%= JSON.stringify(tabs[i].items.map(item => ({ title: utils.stripHtmlTags(item.title || ''), url: utils.stripHtmlTags(item.url || '') }))) %>" />
                           </td>
                           <% if (user.column_preferences?.tabs?.title !== false) { %>
-                          <td style="padding: 10px;"><%~ tabs[i].title %></td>
+                          <td data-label="Group" style="padding: 10px;"><%~ tabs[i].title %></td>
                           <% } %>
                           <% if (user.column_preferences?.tabs?.trigger !== false) { %>
-                          <td style="padding: 10px;"><code><%~ tabs[i].trigger %></code></td>
+                          <td data-label="Trigger" style="padding: 10px;"><code><%~ tabs[i].trigger %></code></td>
                           <% } %>
                           <% if (user.column_preferences?.tabs?.items_count !== false) { %>
-                          <td style="padding: 10px;"><%= tabs[i].items.length %></td>
+                          <td data-label="Items" style="padding: 10px;"><%= tabs[i].items.length %></td>
                           <% } %>
                           <% if (user.column_preferences?.tabs?.created_at !== false) { %>
-                          <td style="padding: 10px;">
+                          <td data-label="Created" style="padding: 10px;">
                             <time datetime="<%= tabs[i].created_at %>">
                                 <%= utils.formatDateInTimezone(tabs[i].created_at, state.user.timezone).fullString %>
                             </time>
                           </td>
                           <% } %>
-                          <td style="padding: 10px;">
+                          <td data-label="Actions" style="padding: 10px;">
                             <details style="position: relative; display: inline-flex; align-items: center;">
                               <summary>Actions</summary>
                               <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 200px; gap: 10px;" role="menu">
@@ -397,12 +397,12 @@ section:has(.tab-checkbox:checked) #delete-selected-btn {
                                 <% for (let j = 0; j < tabs[i].items.length; j++) { %>
                                   <tr>
                                     <% if (user.column_preferences?.tabs?.title !== false) { %>
-                                     <td style="padding: 10px;">
+                                     <td data-label="Item" style="padding: 10px;">
                                        <%~ tabs[i].items[j].title %>
                                      </td>
                                      <% } %>
                                      <% if (user.column_preferences?.tabs?.trigger !== false) { %>
-                                     <td style="padding: 10px;">
+                                     <td data-label="URL" style="padding: 10px;">
                                         <div style="display: flex; gap: 5px; align-items: center;">
                                             <img loading="lazy" src= "<%~ utils.getFaviconUrl(tabs[i].items[j].url) %>" style="width: 16px; height: 16px; border-radius: 50%;">
                                             <span class="preview">
@@ -418,13 +418,13 @@ section:has(.tab-checkbox:checked) #delete-selected-btn {
                                     <td style="padding: 10px;"></td>
                                     <% } %>
                                     <% if (user.column_preferences?.tabs?.created_at !== false) { %>
-                                     <td style="padding: 10px;">
+                                     <td data-label="Created" style="padding: 10px;">
                                        <time datetime="<%= tabs[i].items[j].created_at %>">
                                          <%= utils.formatDateInTimezone(tabs[i].items[j].created_at, state.user.timezone).fullString %>
                                        </time>
                                      </td>
                                      <% } %>
-                                    <td style="padding: 10px;">
+                                    <td data-label="Actions" style="padding: 10px;">
                                       <details style="position: relative; display: inline-flex; align-items: center;">
                                         <summary>Actions</summary>
                                         <div style="position: absolute; top: 100%; left: 0; z-index: 1; border: solid 1px var(--summary-content-border-color); display: flex; flex-direction: column; padding: 10px; background-color: var(--background-color); border-radius: 4px; min-width: 200px; gap: 10px;" role="menu">


### PR DESCRIPTION
## Summary
- improve mobile layout using existing semantic structure instead of new page-specific classes
- switch the actions table to mobile card rows using cell labels
- let settings forms fill small screens and add mobile browser coverage

## Tests
- npm run rebuild:native
- npm test -- src/routes/actions/actions.test.ts src/routes/settings/settings.test.ts
- npm run test:browser:headless -- src/routes/actions/actions.browser-test.ts src/routes/settings/settings.browser-test.ts
- npm run check
- npm run build
- git diff --check

## Manual QA
- checked /actions at a 390px mobile viewport with seeded QA actions: no horizontal overflow, table renders as card rows
- checked /settings/account at a 390px mobile viewport: one-column layout, fieldsets fit viewport, no horizontal overflow