### PR TITLE
fix: prevent cascade data wipe in api_key column drop migration

### DIFF
--- a/src/db/migrations/20260703041218_drop_api_key_columns_from_users.ts
+++ b/src/db/migrations/20260703041218_drop_api_key_columns_from_users.ts
@@ -1,26 +1,30 @@
 import type { Knex } from 'knex';
 
+// Do NOT use knex's dropColumn() here: on SQLite it rebuilds the table via
+// DROP TABLE, and since `PRAGMA foreign_keys = OFF` is ignored inside the
+// migration transaction, the drop cascades into every table referencing
+// users and deletes all user data. Native DROP COLUMN (SQLite 3.35+) does
+// not rebuild the table, so no cascade can fire.
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable('users', (table) => {
-        table.dropIndex('api_key');
-        table.dropUnique(['api_key']);
-    });
+    if (!(await knex.schema.hasColumn('users', 'api_key'))) {
+        return;
+    }
 
-    await knex.schema.alterTable('users', (table) => {
-        table.dropColumn('api_key');
-        table.dropColumn('api_key_version');
-        table.dropColumn('api_key_created_at');
-    });
+    await knex.raw('DROP INDEX IF EXISTS users_api_key_index');
+    await knex.raw('DROP INDEX IF EXISTS users_api_key_unique');
+    await knex.raw('ALTER TABLE users DROP COLUMN api_key');
+    await knex.raw('ALTER TABLE users DROP COLUMN api_key_version');
+    await knex.raw('ALTER TABLE users DROP COLUMN api_key_created_at');
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.schema.alterTable('users', (table) => {
-        table.string('api_key').unique().nullable();
-        table.integer('api_key_version').defaultTo(0).notNullable();
-        table.timestamp('api_key_created_at').nullable();
-    });
+    if (await knex.schema.hasColumn('users', 'api_key')) {
+        return;
+    }
 
-    await knex.schema.alterTable('users', (table) => {
-        table.index('api_key');
-    });
+    await knex.raw('ALTER TABLE users ADD COLUMN api_key varchar(255)');
+    await knex.raw('ALTER TABLE users ADD COLUMN api_key_version integer NOT NULL DEFAULT 0');
+    await knex.raw('ALTER TABLE users ADD COLUMN api_key_created_at datetime');
+    await knex.raw('CREATE UNIQUE INDEX users_api_key_unique ON users (api_key)');
+    await knex.raw('CREATE INDEX users_api_key_index ON users (api_key)');
 }


### PR DESCRIPTION
## What happened

The migration from #435 wiped all user data in production on deploy.

1. knex's `dropColumn()` on SQLite rebuilds the table: create temp copy → copy rows → **`DROP TABLE users`** → rename
2. knex emits `PRAGMA foreign_keys = OFF` around this, but knex migrations run inside a transaction and **SQLite silently ignores that pragma inside a transaction**
3. Our knexfile sets `foreign_keys = ON` on every connection, so `DROP TABLE users` performed an implicit `DELETE FROM users`, firing `ON DELETE CASCADE` on bangs, bookmarks, notes, tabs (→ tab_items), and reminders
4. `users` rows were copied to the rebuilt table, so accounts survived but all their data was deleted

## Fix

Rewrite the migration (same filename, so `knex_migrations` bookkeeping is unchanged) to use SQLite's native `ALTER TABLE ... DROP COLUMN` (3.35+; better-sqlite3 ships 3.53). Native drops modify the schema in place — no table rebuild, no `DROP TABLE`, no cascade. Guarded with `hasColumn` so it's a no-op on DBs where the columns are already gone.

## Verification

- Reproduced the wipe with the old migration in an isolated harness (child rows: 1 → 0 when run inside a transaction)
- Fixed migration in the same harness: child rows survive, columns dropped, re-run is a no-op, `down()` restores columns without touching data
- Ran the app's real migration stack (`CustomMigrationSource` + `migrate.latest()`) against a copy of a production dump: all row counts identical before/after (96 bangs, 313 bookmarks, 44 notes, 1 tab, 5 tab_items, 5 reminders), api_key columns removed
- `npm run check` and `npm test` (799 tests) pass

## Restore note

Merge this BEFORE restoring the pre-wipe DB backup — the restored DB has no record of this migration, so it will run on next startup. With this fix that's safe; with the old version it would wipe the restored data again.