### PR TITLE
fix: respect custom bangs after authentication

### DIFF
--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -96,7 +96,8 @@ describe('search', () => {
             expect(res.status).toBe(200);
             expect(res.set).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    'Cache-Control': 'public, max-age=3600',
+                    'Cache-Control': 'private, max-age=3600',
+                    Vary: 'Cookie',
                 }),
             );
             expect(res.redirect).toHaveBeenCalledWith('https://www.google.com');
@@ -4172,6 +4173,13 @@ describe('Bang Search Optimization', () => {
 
         await searchUtils.search({ req, res });
 
+        expect(res.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                'Cache-Control': 'no-store',
+                Pragma: 'no-cache',
+                Expires: '0',
+            }),
+        );
         expect(res.redirect).toHaveBeenCalledWith('https://www.google.com/search?q=python');
     });
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -569,7 +569,8 @@ export function createSearch(context: AppContext) {
                             res,
                             this.getBangRedirectUrl(bang, ''),
                             searchConfig.redirectWithCacheDuration,
-                            'public',
+                            'private',
+                            ['Cookie'],
                         );
                     }
                 }
@@ -1918,8 +1919,7 @@ export function createSearch(context: AppContext) {
                             res,
                             this.getBangRedirectUrl(bang, searchTerm),
                             searchConfig.redirectWithCacheDuration,
-                            'private',
-                            ['Cookie'], // Vary by Cookie to handle user-specific results
+                            'no-store',
                         );
                     }
 
@@ -1930,7 +1930,7 @@ export function createSearch(context: AppContext) {
                             res,
                             this.getBangRedirectUrl(bang, ''),
                             searchConfig.redirectWithCacheDuration,
-                            'public',
+                            'no-store',
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

- keep anonymous built-in bang redirects cached privately and vary them by cookie
- disable browser caching for authenticated built-in fallback redirects
- cover both cache policies in the search tests

## Root cause

A bare anonymous built-in bang such as `!mgh` returned a public one-hour redirect. Chrome could reuse that redirect after login, skipping the server before it had a chance to check the user's custom actions.

## Behavior

- unauthenticated requests continue using and caching `bang.ts` results
- authenticated requests check custom actions first
- when no custom action exists, authenticated requests fall back to `bang.ts` without caching that redirect

## Validation

- `npm test -- src/utils/search.test.ts` (166 tests)
- `npm run check`
- `npm run build`
- Chrome Computer Use with the existing `bang (dev)` shortcut: signed-out `bd !mgh` opened dMGH; after signing in, the same query opened the custom `!mgh` action
